### PR TITLE
feat: Update attendance creation to use local time

### DIFF
--- a/internal/handlers/teacher/attedance.go
+++ b/internal/handlers/teacher/attedance.go
@@ -23,7 +23,7 @@ func (t *TeacherHandler) CreateAttendance(ctx *fiber.Ctx) error {
 		StudentID:       req.StudentID,
 		SubjectID:       subjectID,
 		AttendaceStatus: req.AttendaceStatus,
-		AttendaceAt:     time.Now(),
+		AttendaceAt:     time.Now().Local(),
 	}
 
 	attendance, err := t.teacherSvc.CreateAttedance(attendance)


### PR DESCRIPTION
This commit updates the attendance creation process in the `CreateAttendance` function of the `TeacherHandler` to use the local time instead of the server time. This change ensures that the attendance timestamp accurately reflects the local time of the student when they mark their attendance.